### PR TITLE
Fix basemap credits. OpenCycleMap -> Thunderforest

### DIFF
--- a/assets/leaflet-0.7.3/js/leaflet-providers.js
+++ b/assets/leaflet-0.7.3/js/leaflet-providers.js
@@ -124,7 +124,7 @@
 			url: '//{s}.tile.thunderforest.com/{variant}/{z}/{x}/{y}.png',
 			options: {
 				attribution:
-					'&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, {attribution.OpenStreetMap}',
+					'&copy; <a href="http://www.thunderforest.com">Thunderforest</a>, {attribution.OpenStreetMap}',
 				variant: 'cycle'
 			},
 			variants: {


### PR DESCRIPTION
Little fix to the credits. The base map tile server is "Thunderforest" not "OpenCycleMap", although OpenCycleMap is produced by the same person, so it's almost right. See also http://www.thunderforest.com/terms/
